### PR TITLE
Use format_html instead of mark_safe in locks

### DIFF
--- a/wagtail/locks.py
+++ b/wagtail/locks.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from django.utils.html import format_html
-from django.utils.safestring import mark_safe
 from django.utils.text import capfirst
 from django.utils.translation import gettext as _
 
@@ -180,14 +179,14 @@ class WorkflowLock(BaseLock):
                 )
                 # Make sure message is correctly capitalised even if it
                 # starts with model_name.
-                workflow_info = mark_safe(capfirst(workflow_info))
+                workflow_info = format_html(capfirst(workflow_info))
 
             reviewers_info = capfirst(
                 _("Only reviewers for this task can edit the %(model_name)s.")
                 % {"model_name": self.model_name}
             )
 
-            return mark_safe(workflow_info + " " + reviewers_info)
+            return format_html("{} {}", workflow_info, reviewers_info)
 
     def get_icon(self, user, can_lock=False):
         if can_lock:
@@ -254,7 +253,7 @@ class ScheduledForPublishLock(BaseLock):
             title=scheduled_revision.object_str,
             datetime=render_timestamp(scheduled_revision.approved_go_live_at),
         )
-        return mark_safe(capfirst(message))
+        return format_html(capfirst(message))
 
     def get_locked_by(self, user):
         return _("Locked by schedule")

--- a/wagtail/snippets/tests/test_locking.py
+++ b/wagtail/snippets/tests/test_locking.py
@@ -4,6 +4,7 @@ from django.contrib.auth.models import Group, Permission
 from django.test import TestCase, override_settings
 from django.urls import NoReverseMatch, reverse
 from django.utils import timezone
+from django.utils.safestring import SafeString
 
 from wagtail.admin.utils import get_user_display_name
 from wagtail.locks import WorkflowLock
@@ -710,8 +711,10 @@ class TestWorkflowLock(BaseLockingTestCase):
         self.assertIsInstance(lock, WorkflowLock)
         self.assertTrue(lock.for_user(self.user))
         self.assertFalse(lock.for_user(self.moderator))
+        message = lock.get_message(self.user)
+        self.assertIsInstance(message, SafeString)
         self.assertEqual(
-            lock.get_message(self.user),
+            message,
             "This full-featured snippet is currently awaiting moderation. "
             "Only reviewers for this task can edit the full-featured snippet.",
         )
@@ -725,8 +728,10 @@ class TestWorkflowLock(BaseLockingTestCase):
         WorkflowTask.objects.create(workflow=workflow, task=other_task, sort_order=2)
 
         lock = self.snippet.get_lock()
+        message = lock.get_message(self.user)
+        self.assertIsInstance(message, SafeString)
         self.assertEqual(
-            lock.get_message(self.user),
+            message,
             "This full-featured snippet is awaiting <b>'test_task'</b> in the "
             "<b>'test_workflow'</b> workflow. Only reviewers for this task "
             "can edit the full-featured snippet.",

--- a/wagtail/tests/test_page_model.py
+++ b/wagtail/tests/test_page_model.py
@@ -14,6 +14,7 @@ from django.test import Client, TestCase, override_settings
 from django.test.client import RequestFactory
 from django.urls import reverse
 from django.utils import timezone, translation
+from django.utils.safestring import SafeString
 from freezegun import freeze_time
 
 from wagtail.actions.copy_for_translation import ParentNotTranslatedError
@@ -3997,8 +3998,10 @@ class TestGetLock(TestCase):
         self.assertIsInstance(lock, WorkflowLock)
         self.assertTrue(lock.for_user(christmas_event.owner))
         self.assertFalse(lock.for_user(moderator))
+        message = lock.get_message(christmas_event.owner)
+        self.assertIsInstance(message, SafeString)
         self.assertEqual(
-            lock.get_message(christmas_event.owner),
+            message,
             "This page is currently awaiting moderation. Only reviewers for this task can edit the page.",
         )
         self.assertIsNone(lock.get_message(moderator))
@@ -4010,8 +4013,10 @@ class TestGetLock(TestCase):
         WorkflowTask.objects.create(workflow=workflow, task=other_task, sort_order=2)
 
         lock = christmas_event.get_lock()
+        message = lock.get_message(christmas_event.owner)
+        self.assertIsInstance(message, SafeString)
         self.assertEqual(
-            lock.get_message(christmas_event.owner),
+            message,
             "This page is awaiting <b>'test_task'</b> in the <b>'test_workflow'</b> workflow. Only reviewers for this task can edit the page.",
         )
 
@@ -4036,8 +4041,10 @@ class TestGetLock(TestCase):
         else:
             expected_date_string = "July 29, 2030, 4:32 p.m."
 
+        message = lock.get_message(christmas_event.owner)
+        self.assertIsInstance(message, SafeString)
         self.assertEqual(
-            lock.get_message(christmas_event.owner),
+            message,
             f"Page 'Christmas' is locked and has been scheduled to go live at {expected_date_string}",
         )
 


### PR DESCRIPTION
## Summary
- replace mark_safe calls in locks with format_html to ensure proper escaping
- test that lock messages remain correct and safe strings

## Testing
- `ruff check wagtail/locks.py wagtail/snippets/tests/test_locking.py wagtail/tests/test_page_model.py`
- `python runtests.py wagtail.snippets.tests.test_locking.TestWorkflowLock.test_when_locked_by_workflow` *(fails: ModuleNotFoundError: No module named 'jinja2')*
- `python runtests.py wagtail.tests.test_page_model.TestGetLock.test_when_locked_by_workflow` *(fails: ModuleNotFoundError: No module named 'jinja2')*

------
https://chatgpt.com/codex/tasks/task_b_68bd1646c234832b9a3df750ad816434

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None; no visible UI changes.
- Bug Fixes
  - Improved safety and consistency of lock messages shown during workflows and scheduled publishing.
- Refactor
  - Standardized HTML handling for lock-related messages to prevent unsafe rendering and ensure proper escaping.
- Tests
  - Enhanced tests to verify lock messages are safely formatted and remain unchanged in content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->